### PR TITLE
Add course repository

### DIFF
--- a/Domain.Contracts/Repositories/ICourseRepository.cs
+++ b/Domain.Contracts/Repositories/ICourseRepository.cs
@@ -1,0 +1,8 @@
+﻿using Domain.Models.Entities;
+
+namespace Domain.Contracts.Repositories
+{
+    public interface ICourseRepository : IInternalRepositoryBase<Course>, IRepositoryBase<Course>
+    {
+    }
+}

--- a/LMS.API/Extensions/ServiceExtensions.cs
+++ b/LMS.API/Extensions/ServiceExtensions.cs
@@ -82,6 +82,7 @@ public static class ServiceExtensions
     public static void AddRepositories(this IServiceCollection services)
     {
         services.AddScoped<IUnitOfWork, UnitOfWork>();
+        services.AddScoped<ICourseRepository, CourseRepository>();
     }
 
     public static void AddServiceLayer(this IServiceCollection services)

--- a/LMS.Infractructure/Repositories/CourseRepository.cs
+++ b/LMS.Infractructure/Repositories/CourseRepository.cs
@@ -1,0 +1,34 @@
+﻿using Domain.Contracts.Repositories;
+using Domain.Models.Entities;
+using System.Linq.Expressions;
+
+namespace LMS.Infractructure.Repositories
+{
+    public class CourseRepository : ICourseRepository
+    {
+        public void Create(Course entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Delete(Course entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IQueryable<Course> FindAll(bool trackChanges = false)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IQueryable<Course> FindByCondition(Expression<Func<Course, bool>> expression, bool trackChanges = false)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Update(Course entity)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/LMS.Infractructure/Repositories/CourseRepository.cs
+++ b/LMS.Infractructure/Repositories/CourseRepository.cs
@@ -1,34 +1,10 @@
 ﻿using Domain.Contracts.Repositories;
 using Domain.Models.Entities;
-using System.Linq.Expressions;
+using LMS.Infractructure.Data;
 
 namespace LMS.Infractructure.Repositories
 {
-    public class CourseRepository : ICourseRepository
+    public class CourseRepository(ApplicationDbContext context) : RepositoryBase<Course>(context), ICourseRepository
     {
-        public void Create(Course entity)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void Delete(Course entity)
-        {
-            throw new NotImplementedException();
-        }
-
-        public IQueryable<Course> FindAll(bool trackChanges = false)
-        {
-            throw new NotImplementedException();
-        }
-
-        public IQueryable<Course> FindByCondition(Expression<Func<Course, bool>> expression, bool trackChanges = false)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void Update(Course entity)
-        {
-            throw new NotImplementedException();
-        }
     }
 }


### PR DESCRIPTION
Addresses https://github.com/orgs/Lexicon-LMS-Group-5/projects/1/views/2?groupedBy%5BcolumnId%5D=Assignees&pane=issue&itemId=168068830&issue=Lexicon-LMS-Group-5%7CLexicon-LMS%7C99

* Adds `ICourseRepository` interface that inherits from `IInternalRepositoryBase` and `IRepositoryBase`
* Adds `CourseRepository` that inherits `RepositoryBase` and implements `ICourseRepository`
*  Registers Course repository in `LMS.API.Extensions/ServiceExtensions.cs`

This PR sets up the CourseRepository structure. If we need database interactions that are specific to the Course entity, these methods should be described in `ICourseRepository` and implemented in the `CourseRepository` class.

Let me know if you have any questions or suggestions :) 