### PR TITLE
Add get course details endpoint

### DIFF
--- a/Domain.Contracts/Repositories/ICourseRepository.cs
+++ b/Domain.Contracts/Repositories/ICourseRepository.cs
@@ -4,7 +4,6 @@ namespace Domain.Contracts.Repositories
 {
     public interface ICourseRepository : IInternalRepositoryBase<Course>, IRepositoryBase<Course>
     {
-        Course? GetCourseDetailsById(int courseId, bool trackChanges = false);
         Task<Course?> GetCourseDetailsByIdAsync(int courseId, bool trackChanges = false);
     }
 }

--- a/Domain.Contracts/Repositories/ICourseRepository.cs
+++ b/Domain.Contracts/Repositories/ICourseRepository.cs
@@ -1,12 +1,10 @@
 ﻿using Domain.Models.Entities;
-using System.Linq.Expressions;
 
 namespace Domain.Contracts.Repositories
 {
     public interface ICourseRepository : IInternalRepositoryBase<Course>, IRepositoryBase<Course>
     {
-        Task<bool> CourseExistsAsync(int courseId);
-
-        Task<Course?> GetCourseDetailsByConditionAsync(Expression<Func<Course, bool>> expression, bool trackChanges = false);
+        Course? GetCourseDetailsById(int courseId, bool trackChanges = false);
+        Task<Course?> GetCourseDetailsByIdAsync(int courseId, bool trackChanges = false);
     }
 }

--- a/Domain.Contracts/Repositories/ICourseRepository.cs
+++ b/Domain.Contracts/Repositories/ICourseRepository.cs
@@ -1,8 +1,12 @@
 ﻿using Domain.Models.Entities;
+using System.Linq.Expressions;
 
 namespace Domain.Contracts.Repositories
 {
     public interface ICourseRepository : IInternalRepositoryBase<Course>, IRepositoryBase<Course>
     {
+        Task<bool> CourseExistsAsync(int courseId);
+
+        Task<Course?> GetCourseDetailsByConditionAsync(Expression<Func<Course, bool>> expression, bool trackChanges = false);
     }
 }

--- a/Domain.Models/Exceptions/CourseNotFoundException.cs
+++ b/Domain.Models/Exceptions/CourseNotFoundException.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Domain.Models.Exceptions
+{
+    public class CourseNotFoundException() : NotFoundException("Course not found")
+    {
+    }
+}

--- a/LMS.API/Extensions/ServiceExtensions.cs
+++ b/LMS.API/Extensions/ServiceExtensions.cs
@@ -91,5 +91,8 @@ public static class ServiceExtensions
 
         services.AddScoped<IAuthService, AuthService>();
         services.AddScoped(provider => new Lazy<IAuthService>(() => provider.GetRequiredService<IAuthService>()));
+
+        services.AddScoped<ICourseService, CourseService>();
+        services.AddScoped(provider => new Lazy<ICourseService>(() => provider.GetRequiredService<ICourseService>()));
     }
 }

--- a/LMS.Infractructure/Data/MapperProfile.cs
+++ b/LMS.Infractructure/Data/MapperProfile.cs
@@ -12,5 +12,6 @@ public class MapperProfile : Profile
         CreateMap<UserRegistrationDto, ApplicationUser>();
         CreateMap<Course, CourseDetailsDto>();
         CreateMap<ApplicationUser, CourseParticipantWithRoleInfoDto>();
+        CreateMap<Module, CourseModuleListItemDto>();
     }
 }

--- a/LMS.Infractructure/Data/MapperProfile.cs
+++ b/LMS.Infractructure/Data/MapperProfile.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using Domain.Models.Entities;
+using LMS.Shared.DTOs;
 using LMS.Shared.DTOs.AuthDtos;
 
 namespace LMS.Infractructure.Data;
@@ -9,5 +10,7 @@ public class MapperProfile : Profile
     public MapperProfile()
     {
         CreateMap<UserRegistrationDto, ApplicationUser>();
+        CreateMap<Course, CourseDetailsDto>();
+        CreateMap<ApplicationUser, CourseParticipantWithRoleInfoDto>();
     }
 }

--- a/LMS.Infractructure/Repositories/CourseRepository.cs
+++ b/LMS.Infractructure/Repositories/CourseRepository.cs
@@ -1,10 +1,27 @@
 ﻿using Domain.Contracts.Repositories;
 using Domain.Models.Entities;
 using LMS.Infractructure.Data;
+using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
 
 namespace LMS.Infractructure.Repositories
 {
     public class CourseRepository(ApplicationDbContext context) : RepositoryBase<Course>(context), ICourseRepository
     {
+        ApplicationDbContext context = context;
+        public async Task<bool> CourseExistsAsync(int courseId)
+        {
+            return await context.Courses.FindAsync(courseId) is not null;
+        }
+
+        public async Task<Course?> GetCourseDetailsByConditionAsync(Expression<Func<Course, bool>> expression, bool trackChanges = false)
+        {
+            var baseQuery = !trackChanges ? context.Courses.AsNoTracking() : context.Courses;
+
+            return await FindByCondition(expression, trackChanges)
+                .Include(c => c.Participants)
+                .Include(c => c.Modules)
+                .SingleAsync();
+        }
     }
 }

--- a/LMS.Infractructure/Repositories/CourseRepository.cs
+++ b/LMS.Infractructure/Repositories/CourseRepository.cs
@@ -2,23 +2,28 @@
 using Domain.Models.Entities;
 using LMS.Infractructure.Data;
 using Microsoft.EntityFrameworkCore;
-using System.Linq.Expressions;
 
 namespace LMS.Infractructure.Repositories
 {
     public class CourseRepository(ApplicationDbContext context) : RepositoryBase<Course>(context), ICourseRepository
     {
-        ApplicationDbContext context = context;
-        public async Task<bool> CourseExistsAsync(int courseId)
-        {
-            return await context.Courses.FindAsync(courseId) is not null;
-        }
+        private readonly ApplicationDbContext context = context;
 
-        public async Task<Course?> GetCourseDetailsByConditionAsync(Expression<Func<Course, bool>> expression, bool trackChanges = false)
+        public Course? GetCourseDetailsById(int courseId, bool trackChanges = false)
         {
             var baseQuery = !trackChanges ? context.Courses.AsNoTracking() : context.Courses;
 
-            return await FindByCondition(expression, trackChanges)
+            return FindByCondition(c => c.Id == courseId, trackChanges)
+                .Include(c => c.Participants)
+                .Include(c => c.Modules)
+                .Single();
+        }
+
+        public async Task<Course?> GetCourseDetailsByIdAsync(int courseId, bool trackChanges = false)
+        {
+            var baseQuery = !trackChanges ? context.Courses.AsNoTracking() : context.Courses;
+
+            return await FindByCondition(c => c.Id == courseId, trackChanges)
                 .Include(c => c.Participants)
                 .Include(c => c.Modules)
                 .SingleAsync();

--- a/LMS.Infractructure/Repositories/CourseRepository.cs
+++ b/LMS.Infractructure/Repositories/CourseRepository.cs
@@ -16,6 +16,7 @@ namespace LMS.Infractructure.Repositories
             return FindByCondition(c => c.Id == courseId, trackChanges)
                 .Include(c => c.Participants)
                 .Include(c => c.Modules)
+                    .ThenInclude(m => m.Activities)
                 .Single();
         }
 
@@ -26,6 +27,7 @@ namespace LMS.Infractructure.Repositories
             return await FindByCondition(c => c.Id == courseId, trackChanges)
                 .Include(c => c.Participants)
                 .Include(c => c.Modules)
+                    .ThenInclude(m => m.Activities)
                 .SingleAsync();
         }
     }

--- a/LMS.Infractructure/Repositories/CourseRepository.cs
+++ b/LMS.Infractructure/Repositories/CourseRepository.cs
@@ -9,17 +9,6 @@ namespace LMS.Infractructure.Repositories
     {
         private readonly ApplicationDbContext context = context;
 
-        public Course? GetCourseDetailsById(int courseId, bool trackChanges = false)
-        {
-            var baseQuery = !trackChanges ? context.Courses.AsNoTracking() : context.Courses;
-
-            return FindByCondition(c => c.Id == courseId, trackChanges)
-                .Include(c => c.Participants)
-                .Include(c => c.Modules)
-                    .ThenInclude(m => m.Activities)
-                .Single();
-        }
-
         public async Task<Course?> GetCourseDetailsByIdAsync(int courseId, bool trackChanges = false)
         {
             var baseQuery = !trackChanges ? context.Courses.AsNoTracking() : context.Courses;

--- a/LMS.Presentation/Controllers/CourseEndpoints/GetCourseDetails.cs
+++ b/LMS.Presentation/Controllers/CourseEndpoints/GetCourseDetails.cs
@@ -1,0 +1,22 @@
+﻿using LMS.Shared.DTOs;
+using Microsoft.AspNetCore.Mvc;
+using Service.Contracts;
+
+namespace LMS.Presentation.Controllers.CourseEndpoints
+{
+    [Route("api/courses")]
+    [ApiController]
+    public partial class CourseController(IServiceManager serviceManager) : ControllerBase
+    {
+        private readonly ICourseService courseService = serviceManager.CourseService;
+    
+
+        [HttpGet("{id:int}")]
+        public async Task<IActionResult> GetCourseDetails([FromRoute] int id)
+        {
+            var result = await courseService.GetCourseDetailsAsync(new CourseDetailsQueryDto(id));
+
+            return Ok(result);
+        }
+    }
+}

--- a/LMS.Presentation/Controllers/CourseEndpoints/GetCourseDetails.cs
+++ b/LMS.Presentation/Controllers/CourseEndpoints/GetCourseDetails.cs
@@ -1,15 +1,16 @@
 ﻿using LMS.Shared.DTOs;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Service.Contracts;
 
 namespace LMS.Presentation.Controllers.CourseEndpoints
 {
+    [Authorize]
     [Route("api/courses")]
     [ApiController]
     public partial class CourseController(IServiceManager serviceManager) : ControllerBase
     {
         private readonly ICourseService courseService = serviceManager.CourseService;
-    
 
         [HttpGet("{id:int}")]
         public async Task<IActionResult> GetCourseDetails([FromRoute] int id)

--- a/LMS.Services/CourseService.cs
+++ b/LMS.Services/CourseService.cs
@@ -1,0 +1,16 @@
+﻿using LMS.Shared.DTOs;
+using Service.Contracts;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LMS.Services
+{
+    public class CourseService : ICourseService
+    {
+        public Task<CourseDetailsDto> GetCourseDetailsAsync(CourseDetailsQueryDto query)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/LMS.Services/CourseService.cs
+++ b/LMS.Services/CourseService.cs
@@ -1,16 +1,49 @@
-﻿using LMS.Shared.DTOs;
+﻿using AutoMapper;
+using Domain.Contracts.Repositories;
+using Domain.Models.Entities;
+using Domain.Models.Exceptions;
+using LMS.Shared.DTOs;
+using Microsoft.AspNetCore.Identity;
 using Service.Contracts;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace LMS.Services
 {
     public class CourseService : ICourseService
     {
-        public Task<CourseDetailsDto> GetCourseDetailsAsync(CourseDetailsQueryDto query)
+        private readonly ICourseRepository courseRepository;
+        private readonly UserManager<ApplicationUser> userManager;
+        private readonly IMapper mapper;
+
+        public CourseService(
+            ICourseRepository courseRepository, 
+            UserManager<ApplicationUser> userManager, 
+            IMapper mapper)
         {
-            throw new NotImplementedException();
+            this.courseRepository = courseRepository;
+            this.userManager = userManager;
+            this.mapper = mapper;
+        }
+
+        public async Task<CourseDetailsDto> GetCourseDetailsAsync(CourseDetailsQueryDto query)
+        {
+            var course = courseRepository.GetCourseDetailsById(query.CourseId)
+                ?? throw new CourseNotFoundException();
+
+            List<CourseParticipantWithRoleInfoDto> courceParticipantsWithRoleInfo = [];
+
+            var courseDetailsDto = mapper.Map<CourseDetailsDto>(course);
+
+            foreach (var user in course.Participants)
+            {
+                var roles = await userManager.GetRolesAsync(user);
+                var coursePaticipantWithRoleInfo = mapper.Map<CourseParticipantWithRoleInfoDto>(user);
+                coursePaticipantWithRoleInfo.Role = roles.FirstOrDefault() ?? "";
+
+                courceParticipantsWithRoleInfo.Add(coursePaticipantWithRoleInfo);
+            }
+
+            courseDetailsDto.Participants = courceParticipantsWithRoleInfo;
+            return courseDetailsDto;
         }
     }
 }

--- a/LMS.Services/CourseService.cs
+++ b/LMS.Services/CourseService.cs
@@ -26,7 +26,7 @@ namespace LMS.Services
 
         public async Task<CourseDetailsDto> GetCourseDetailsAsync(CourseDetailsQueryDto query)
         {
-            var course = courseRepository.GetCourseDetailsById(query.CourseId)
+            var course = await courseRepository.GetCourseDetailsByIdAsync(query.CourseId)
                 ?? throw new CourseNotFoundException();
 
             List<CourseParticipantWithRoleInfoDto> courceParticipantsWithRoleInfo = [];

--- a/LMS.Services/ServiceManager.cs
+++ b/LMS.Services/ServiceManager.cs
@@ -5,10 +5,16 @@ namespace LMS.Services;
 public class ServiceManager : IServiceManager
 {
     private Lazy<IAuthService> authService;
-    public IAuthService AuthService => authService.Value;
+    private Lazy<ICourseService> courseService;
 
-    public ServiceManager(Lazy<IAuthService> authService)
+    public IAuthService AuthService => authService.Value;
+    public ICourseService CourseService => courseService.Value;
+
+    public ServiceManager(
+        Lazy<IAuthService> authService, 
+        Lazy<ICourseService> courseService)
     {
         this.authService = authService;
+        this.courseService = courseService;
     }
 }

--- a/LMS.Shared/DTOs/CourseDtos.cs
+++ b/LMS.Shared/DTOs/CourseDtos.cs
@@ -21,11 +21,11 @@
 
     public class CourseDetailsDto : CourseReadDto
     {
-        IEnumerable<CourseParticipantsWithRoleInfoDto> Participants { get; set; } = [];
-        IEnumerable<CourseModuleListItemDto> Modules { get; set; } = [];
+        public IEnumerable<CourseParticipantWithRoleInfoDto> Participants { get; set; } = [];
+        public IEnumerable<CourseModuleListItemDto> Modules { get; set; } = [];
     }
 
-    public class CourseParticipantsWithRoleInfoDto
+    public class CourseParticipantWithRoleInfoDto
     {
         public int Id { get; set; }
         public string FullName { get; set; } = string.Empty;

--- a/LMS.Shared/DTOs/CourseDtos.cs
+++ b/LMS.Shared/DTOs/CourseDtos.cs
@@ -27,7 +27,7 @@
 
     public class CourseParticipantWithRoleInfoDto
     {
-        public int Id { get; set; }
+        public string Id { get; set; } = default!;
         public string FullName { get; set; } = string.Empty;
         public string Email { get; set; } = string.Empty;
         public string Role { get; set; } = string.Empty;

--- a/LMS.Shared/DTOs/CourseDtos.cs
+++ b/LMS.Shared/DTOs/CourseDtos.cs
@@ -2,8 +2,8 @@
 {
     public class CourseUpsertDto
     {
-        public string Name { get; set; }
-        public string Description { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
         public DateTime StartDate { get; set; }
         public DateTime EndDate { get; set; }
     }
@@ -11,9 +11,32 @@
     public class CourseReadDto
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public string Description { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
         public DateTime StartDate { get; set; }
         public DateTime EndDate { get; set; }
+    }
+
+    public record CourseDetailsQueryDto(int CourseId);
+
+    public class CourseDetailsDto : CourseReadDto
+    {
+        IEnumerable<CourseParticipantsWithRoleInfoDto> Participants { get; set; } = [];
+        IEnumerable<CourseModuleListItemDto> Modules { get; set; } = [];
+    }
+
+    public class CourseParticipantsWithRoleInfoDto
+    {
+        public int Id { get; set; }
+        public string FullName { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public string Role { get; set; } = string.Empty;
+    }
+
+    public class CourseModuleListItemDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
     }
 }

--- a/Service.Contracts/ICourseService.cs
+++ b/Service.Contracts/ICourseService.cs
@@ -1,0 +1,9 @@
+﻿using LMS.Shared.DTOs;
+
+namespace Service.Contracts
+{
+    public interface ICourseService
+    {
+        Task<CourseDetailsDto> GetCourseDetailsAsync(CourseDetailsQueryDto query);
+    }
+}

--- a/Service.Contracts/IServiceManager.cs
+++ b/Service.Contracts/IServiceManager.cs
@@ -2,4 +2,5 @@
 public interface IServiceManager
 {
     IAuthService AuthService { get; }
+    ICourseService CourseService { get; }
 }


### PR DESCRIPTION
This PR needs https://github.com/Lexicon-LMS-Group-5/Lexicon-LMS/pull/113 before merging.

* Adds a GetCourseDetails endpoint to the Course controller (implemented here as a partial class to avoid conflicts with any ongoing work on the CourseController. Can be moved to the main CourseController class when ready)
* Endpoint is `/api/courses/{courseId}`

Response in Postman:

<img width="1015" height="936" alt="Get Course Details 1" src="https://github.com/user-attachments/assets/c224d452-f3d7-4238-a1c8-35fb6784f0dc" />

<img width="1009" height="512" alt="Get Course Details 2" src="https://github.com/user-attachments/assets/a4ea4f22-0f54-4435-a1c0-0a4e8e9b1ff4" />
