### PR TITLE
fix: add missing IModuleRepository dependency injection

### DIFF
--- a/LMS.API/Extensions/ServiceExtensions.cs
+++ b/LMS.API/Extensions/ServiceExtensions.cs
@@ -86,6 +86,9 @@ public static class ServiceExtensions
         services.AddScoped<ICourseRepository, CourseRepository>();
         services.AddScoped(provider => new Lazy<ICourseRepository>(() => provider.GetRequiredService<ICourseRepository>()));
 
+        services.AddScoped<IModuleRepository, ModuleRepository>();
+        services.AddScoped(provider => new Lazy<IModuleRepository>(() => provider.GetRequiredService<IModuleRepository>()));
+
         services.AddScoped<IActivityRepository, ActivityRepository>();
         services.AddScoped(provider => new Lazy<IActivityRepository>(() => provider.GetRequiredService<IActivityRepository>()));
     }


### PR DESCRIPTION
Was missing in `LMS.API.Extentions/ServiceExtensions.cs`