### PR TITLE
Add course creation API endpoint

### DIFF
--- a/Domain.Models/Exceptions/CourseCreationException.cs
+++ b/Domain.Models/Exceptions/CourseCreationException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Domain.Models.Exceptions;
+
+public class CourseCreationException : BadRequestException
+{
+    public CourseCreationException() : base("Could not create course")
+    {
+
+    }
+    public CourseCreationException(string message) : base(message)
+    {
+
+    }
+}

--- a/Domain.Models/Exceptions/UserNotFoundException.cs
+++ b/Domain.Models/Exceptions/UserNotFoundException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Domain.Models.Exceptions
+{
+    public class UserNotFoundException : NotFoundException
+    {
+        public UserNotFoundException() : base("User not found") 
+        { 
+        }
+
+        public UserNotFoundException(string message) : base(message) 
+        { 
+        }
+    }
+}

--- a/LMS.API/Extensions/ServiceExtensions.cs
+++ b/LMS.API/Extensions/ServiceExtensions.cs
@@ -86,6 +86,9 @@ public static class ServiceExtensions
         services.AddScoped<ICourseRepository, CourseRepository>();
         services.AddScoped(provider => new Lazy<ICourseRepository>(() => provider.GetRequiredService<ICourseRepository>()));
 
+        services.AddScoped<IModuleRepository, ModuleRepository>();
+        services.AddScoped(provider => new Lazy<IModuleRepository>(() => provider.GetRequiredService<IModuleRepository>()));
+
         services.AddScoped<IActivityRepository, ActivityRepository>();
         services.AddScoped(provider => new Lazy<IActivityRepository>(() => provider.GetRequiredService<IActivityRepository>()));
     }

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/Home.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/Home.razor
@@ -14,7 +14,10 @@ Welcome to your new app.
         <ul>
             @foreach(var course in PageState.Data.Items)
             {
-                <li>@course.Name</li>
+                <li>
+                    <div>@course.Name</div>
+                    <div>@course.Description</div>
+                </li>
             }
         </ul>
     }

--- a/LMS.Infractructure/Data/MapperProfile.cs
+++ b/LMS.Infractructure/Data/MapperProfile.cs
@@ -11,6 +11,7 @@ public class MapperProfile : Profile
     public MapperProfile()
     {
         CreateMap<UserRegistrationDto, ApplicationUser>();
+        CreateMap<CreateCourseCommandDto, Course>();
         CreateMap<Course, CourseListItemDto>();
         CreateMap<IEnumerable<Course>, IReadOnlyList<CourseListItemDto>>();
         CreateMap<BasePageQueryDto, PagedResultMetaDataDto>();

--- a/LMS.Infractructure/Repositories/CourseRepository.cs
+++ b/LMS.Infractructure/Repositories/CourseRepository.cs
@@ -9,11 +9,9 @@ namespace LMS.Infractructure.Repositories
 {
     public class CourseRepository(ApplicationDbContext context) : RepositoryBase<Course>(context), ICourseRepository
     {
-        private readonly ApplicationDbContext context = context;
-
         public async Task<IEnumerable<Course>> FindAllByConditionAsync(CoursesQueryDto query, bool trackChanges = false, CancellationToken ct = default)
         {
-            var baseQuery = !trackChanges ? context.Courses.AsNoTracking() : context.Courses;
+            var baseQuery = FindAll(trackChanges);
 
             // ToDo: Use an OrderBy query parameter?
             var orderedCourses = query.Order == SortOrder.Ascending
@@ -28,8 +26,6 @@ namespace LMS.Infractructure.Repositories
 
         public async Task<Course?> GetCourseDetailsByIdAsync(int courseId, bool trackChanges = false, CancellationToken ct = default)
         {
-            var baseQuery = !trackChanges ? context.Courses.AsNoTracking() : context.Courses;
-
             return await FindByCondition(c => c.Id == courseId, trackChanges)
                 .Include(c => c.Participants)
                 .Include(c => c.Modules)

--- a/LMS.Presentation/Controllers/CourseController.cs
+++ b/LMS.Presentation/Controllers/CourseController.cs
@@ -36,4 +36,14 @@ public class CourseController : ControllerBase
 
         return Ok(result);
     }
+
+    [Authorize(Roles = "Teacher")]
+    [HttpPost("create")]
+    [ProducesResponseType<CreateCourseResultDto>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> CreateCourse([FromBody] CreateCourseCommandDto command)
+    {
+        var result = await serviceManager.CourseService.CreateCourseAsync(command);
+
+        return Ok(result);
+    }
 }

--- a/LMS.Services/CourseService.cs
+++ b/LMS.Services/CourseService.cs
@@ -119,7 +119,9 @@ namespace LMS.Services
 
             await unitOfWork.CompleteAsync();
 
-            return new(course.Id);
+            return new CreateCourseResultDto {
+                CreatedCourse = mapper.Map<CourseListItemDto>(course)
+            };
         }
     }
 }

--- a/LMS.Services/CourseService.cs
+++ b/LMS.Services/CourseService.cs
@@ -64,5 +64,32 @@ namespace LMS.Services
             courseDetailsDto.Participants = courceParticipantsWithRoleInfo;
             return courseDetailsDto;
         }
+
+        public async Task<CreateCourseResultDto> CreateCourseAsync(CreateCourseCommandDto command, CancellationToken ct = default)
+        {
+            if (command.CreatorId == null || command.CreatorId.IsWhiteSpace()) 
+                throw new BadRequestException("A user Id must be provided to create this resource");
+            var user = await userManager.FindByIdAsync(command.CreatorId) 
+                ?? throw new UserNotFoundException($"User with ID {command.CreatorId} could not be found");
+            
+            // Initialize the course to be created
+            var course = mapper.Map<Course>(command);
+
+            // ToDo: add all validation rules
+            // A Course can be created if...
+
+            // 1) It has a valid Name
+            course.Name = command.Name.Trim();
+
+            // Check if the Course creator should be added to the course
+            if (command.AddCreator)
+                course.Participants.Add(user);
+
+            unitOfWork.Courses.Create(course);
+
+            await unitOfWork.CompleteAsync();
+
+            return new(course.Id);
+        }
     }
 }

--- a/LMS.Services/CourseService.cs
+++ b/LMS.Services/CourseService.cs
@@ -68,18 +68,48 @@ namespace LMS.Services
         public async Task<CreateCourseResultDto> CreateCourseAsync(CreateCourseCommandDto command, CancellationToken ct = default)
         {
             if (command.CreatorId == null || command.CreatorId.IsWhiteSpace()) 
-                throw new BadRequestException("A user Id must be provided to create this resource");
+                throw new CourseCreationException("A user Id must be provided to create this resource");
+
             var user = await userManager.FindByIdAsync(command.CreatorId) 
                 ?? throw new UserNotFoundException($"User with ID {command.CreatorId} could not be found");
+
+            if (!await userManager.IsInRoleAsync(user, "Teacher"))
+                throw new TokenValidationException("User is not authorized to create a Course");
             
             // Initialize the course to be created
             var course = mapper.Map<Course>(command);
 
-            // ToDo: add all validation rules
+            // Check Course creation rules:
             // A Course can be created if...
 
-            // 1) It has a valid Name
-            course.Name = command.Name.Trim();
+            // 1) it has a valid Name
+            var validatedName = command.Name.Trim();
+            if (validatedName.Length < 0 || validatedName.Length > 35)
+                throw new CourseCreationException($"Could not create Course with invalid {nameof(course.Name)}");
+
+            // 2) it has a valid Description
+            var validatedDescription = command.Description.Trim();
+            if (validatedDescription.Length > 160)
+                throw new CourseCreationException($"Could not create Course with invalid {nameof(course.Description)}");
+
+            // 3) it has a valid StartDate
+            var validatedStartDate = command.StartDate 
+                ?? throw new CourseCreationException($"Could not create Course with invalid {nameof(course.StartDate)}");
+
+            // 4) it has a valid EndDate
+            var validatedEndDate = command.EndDate
+                ?? throw new CourseCreationException($"Could not create Course with invalid {nameof(course.EndDate)}");
+
+            // 5) EndDate is after StartDate
+            if (validatedEndDate <= validatedStartDate)
+                throw new CourseCreationException($"Could not create Course. {nameof(course.EndDate)} must be after {nameof(course.StartDate)}");
+
+            // Set validated properties
+            course.Name = validatedName;
+            course.Description = validatedDescription;
+            course.StartDate = validatedStartDate;
+            course.StartDate = validatedStartDate;
+            course.EndDate = validatedEndDate;
 
             // Check if the Course creator should be added to the course
             if (command.AddCreator)

--- a/LMS.Shared/DTOs/CourseDtos.cs
+++ b/LMS.Shared/DTOs/CourseDtos.cs
@@ -92,9 +92,9 @@ namespace LMS.Shared.DTOs
         }
     }
 
-    public class CreateCourseResultDto(int id)
+    public class CreateCourseResultDto
     {
-        public int CourseId { get; set; } = id;
+        public CourseListItemDto CreatedCourse { get; set; } = default!;
     }
 
     public class CourseListItemDto : CourseReadDto

--- a/LMS.Shared/DTOs/CourseDtos.cs
+++ b/LMS.Shared/DTOs/CourseDtos.cs
@@ -1,13 +1,14 @@
 ﻿using LMS.Shared.DTOs.PagingDtos;
+using System.ComponentModel.DataAnnotations;
 
 namespace LMS.Shared.DTOs
 {
     public class CourseUpsertDto
     {
-        public string Name { get; set; } = string.Empty;
-        public string Description { get; set; } = string.Empty;
-        public DateTime StartDate { get; set; }
-        public DateTime EndDate { get; set; }
+        public virtual string Name { get; set; } = string.Empty;
+        public virtual string Description { get; set; } = string.Empty;
+        public virtual DateTime? StartDate { get; set; }
+        public virtual DateTime? EndDate { get; set; }
     }
 
     public class CourseReadDto
@@ -52,7 +53,48 @@ namespace LMS.Shared.DTOs
 
     public class CoursesQueryResultDto : BasePagedResultDto<CourseListItemDto>
     {
+        
+    }
 
+    public class CreateCourseCommandDto : CourseUpsertDto, IValidatableObject
+    {
+        public string CreatorId { get; set; } = string.Empty;
+
+        [Required]
+        [StringLength(35, MinimumLength = 1)]
+        public override string Name { get; set; }
+
+        [StringLength(160)]
+        public override string Description { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Date)]
+        public override DateTime? StartDate { get; set; }
+
+        [Required]
+        [DataType(DataType.Date)]
+        public override DateTime? EndDate { get; set; }
+
+        [Required]
+        public bool AddCreator { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (EndDate <= StartDate)
+            {
+                yield return new ValidationResult("End date must be after the start date.", [nameof(EndDate)]);
+            }
+
+            if (EndDate <= DateTime.UtcNow)
+            {
+                yield return new ValidationResult("End date must be in the future", [nameof(EndDate)]);
+            }
+        }
+    }
+
+    public class CreateCourseResultDto(int id)
+    {
+        public int CourseId { get; set; } = id;
     }
 
     public class CourseListItemDto : CourseReadDto

--- a/Service.Contracts/ICourseService.cs
+++ b/Service.Contracts/ICourseService.cs
@@ -6,5 +6,6 @@ namespace Service.Contracts
     {
         Task<CoursesQueryResultDto> GetCoursesAsync(CoursesQueryDto query, CancellationToken ct = default);
         Task<CourseDetailsDto> GetCourseDetailsAsync(CourseDetailsQueryDto query, CancellationToken ct = default);
+        Task<CreateCourseResultDto> CreateCourseAsync(CreateCourseCommandDto command, CancellationToken ct = default);
     }
 }


### PR DESCRIPTION
Addresses https://github.com/Lexicon-LMS-Group-5/Lexicon-LMS/issues/125 and https://github.com/Lexicon-LMS-Group-5/Lexicon-LMS/issues/126

* Adds `CreateCourseCommandDto` and `CreateCourseResultDto`
* Adds `CreateCourseAsync` to CourseService
* Adds `POST /api/courses/create` endpoint
* Removes direct usage of context in CourseRepository
* Can be tested with Postman:

_Successful POST request:_

<img width="968" height="711" alt="Create Course POST request" src="https://github.com/user-attachments/assets/49adbec2-e856-40f5-9067-44ff2fae7c01" />

_POST request with validation error:_

<img width="972" height="727" alt="Create Course POST validation error" src="https://github.com/user-attachments/assets/29447cbd-d448-4881-8199-1bac5e7d60e5" />

