### PR TITLE
set overview tab as default in Dashboard NavLink

### DIFF
--- a/LMS.Blazor/LMS.Blazor.Client/Layout/NavMenu.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Layout/NavMenu.razor
@@ -21,7 +21,7 @@
             <AuthorizeView Roles="Teacher">
                 <Authorized>
                     <div class="nav-item">
-                        <NavLink class="nav-link" href="" Match="NavLinkMatch.All" @onclick="CloseMenu">
+                        <NavLink class="nav-link" href="?tab=overview" Match="NavLinkMatch.All" @onclick="CloseMenu">
                             <span class="nav-icon"><HouseIcon /></span>
                             <span>Dashboard</span>
                         </NavLink>


### PR DESCRIPTION
Fixes broken tabs state when clicking the Dashboard Navlink when already on the Dashboard page.