### PR TITLE
fix: remove login redirect based on unimplemented Input.Role

### DIFF
--- a/LMS.Blazor/LMS.Blazor/Components/Account/Pages/Login.razor
+++ b/LMS.Blazor/LMS.Blazor/Components/Account/Pages/Login.razor
@@ -185,13 +185,7 @@
                 }
             }
 
-            if (Input.Role == "Teacher")
-            {
-                RedirectManager.RedirectTo("/teacher");
-                return;
-            }
-
-            RedirectManager.RedirectTo(ReturnUrl ?? "/student");
+            RedirectManager.RedirectTo(ReturnUrl ?? "/my-course");
         }
         else if (result.RequiresTwoFactor)
         {


### PR DESCRIPTION
The Login page is currently redirecting to nonexistent pages `/student` and `/teacher`. The redirection is based on a "Role" property on the `InputModel` defined at the bottom of the file. I don't believe we are setting this property anywhere in the code on login, so it is currently defaulting to "Student" which redirects to the `/student` page resulting in a 404.

This PR sets the redirect to the return url or `/my-course`.